### PR TITLE
Call `result` end of methods

### DIFF
--- a/android/src/main/java/com/flutter/text_to_speech/FlutterTextToSpeech.java
+++ b/android/src/main/java/com/flutter/text_to_speech/FlutterTextToSpeech.java
@@ -75,6 +75,7 @@ class FlutterTextToSpeech implements TTSAgent, TextToSpeech.OnInitListener {
         long delay = Long.parseLong(options.get("delay").toString())*1000;
         ttsAgent.playSilentUtterance(delay, TextToSpeech.QUEUE_FLUSH, UUID.randomUUID().toString());
         ttsAgent.speak(text, TextToSpeech.QUEUE_ADD, bundle, UUID.randomUUID().toString());
+        result.success(true);
     }
 
     @Override
@@ -84,6 +85,7 @@ class FlutterTextToSpeech implements TTSAgent, TextToSpeech.OnInitListener {
         ttsAgent = null;
         initResult = null;
         bundle.clear();
+        result.success(true);
     }
 
 }

--- a/ios/Classes/FlutterTextToSpeechPlugin.m
+++ b/ios/Classes/FlutterTextToSpeechPlugin.m
@@ -86,12 +86,14 @@ NSMutableArray<NSString *> *ttsLanguageSet;
     utterance.voice = selectedVoice;
     [synth speakUtterance:utterance];
     [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:&error];
+    result(@(YES));
 }
 
 + (void)stop:(FlutterResult)result{
     [synth stopSpeakingAtBoundary:AVSpeechBoundaryImmediate];
     NSError *error;
     [[AVAudioSession sharedInstance] setActive:NO withOptions:AVAudioSessionSetActiveOptionNotifyOthersOnDeactivation error:&error];
+    result(@(YES));
 }
 
 @end


### PR DESCRIPTION
Currently `Future` never complete.

```dart
VoiceController voiceController = ...;
await voiceController.stop();
// Never reached because `result` isn't called.
```